### PR TITLE
Enabled should be enabled and not disabled

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,7 @@ resource "azurerm_route_table" "vgw" {
   location                      = var.location
   name                          = coalesce(var.route_table_name, "rt-${var.name}")
   resource_group_name           = coalesce(var.route_table_resource_group_name, local.virtual_network_resource_group_name)
-  bgp_route_propagation_enabled = !var.route_table_bgp_route_propagation_enabled
+  bgp_route_propagation_enabled = var.route_table_bgp_route_propagation_enabled
   tags                          = merge(var.tags, var.route_table_tags)
 }
 


### PR DESCRIPTION
## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

Currently `route_table_bgp_route_propagation_enabled = true` is disabling the bgp route propagation and not enabling


## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [x] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
