### PR TITLE
Removing default zones configuration on Public Ip resources

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -148,7 +148,7 @@ variable "ip_configurations" {
       allocation_method       = optional(string, "Static")
       sku                     = optional(string, "Standard")
       tags                    = optional(map(string), {})
-      zones                   = optional(list(number), [1, 2, 3])
+      zones                   = optional(list(number), [])
       edge_zone               = optional(string, null)
       ddos_protection_mode    = optional(string, "VirtualNetworkInherited")
       ddos_protection_plan_id = optional(string, null)


### PR DESCRIPTION
## Description
There is an issue when you try to deploy a VPN GW with a standard public IP, no active-active mode it always setup the zones by default. This PR just remove the default values to create zone on public IPs during the creation of VPN gateway'.
Fixes Azure/terraform-azurerm-avm-ptn-alz-connectivity-hub-and-spoke-vnet#63 

-->

## Type of Change

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ x] Azure Verified Module updates:
  - [ x] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ x] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
