### PR TITLE
fix: hobo public ip

### DIFF
--- a/examples/default-with-hobo-ip/README.md
+++ b/examples/default-with-hobo-ip/README.md
@@ -1,0 +1,107 @@
+<!-- BEGIN_TF_DOCS -->
+# Default Example
+
+This code sample shows how to create the resources using default settings.
+
+```hcl
+resource "random_id" "id" {
+  byte_length = 4
+}
+
+locals {
+  location = "swedencentral"
+}
+
+resource "azurerm_resource_group" "rg" {
+  location = local.location
+  name     = "rg-vnetgateway-${random_id.id.hex}"
+}
+
+resource "azurerm_virtual_network" "vnet" {
+  location            = azurerm_resource_group.rg.location
+  name                = "vnet-${random_id.id.hex}"
+  resource_group_name = azurerm_resource_group.rg.name
+  address_space       = ["10.0.0.0/16"]
+}
+
+module "vgw" {
+  source = "../.."
+
+  location              = azurerm_resource_group.rg.location
+  name                  = "vgw-${random_id.id.hex}"
+  subnet_address_prefix = "10.0.1.0/24"
+  virtual_network_id    = azurerm_virtual_network.vnet.id
+}
+
+```
+
+<!-- markdownlint-disable MD033 -->
+## Requirements
+
+The following requirements are needed by this module:
+
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>=1.2)
+
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
+
+- <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.5.0)
+
+## Resources
+
+The following resources are used by this module:
+
+- [azurerm_resource_group.rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) (resource)
+- [azurerm_virtual_network.vnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network) (resource)
+- [random_id.id](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) (resource)
+
+<!-- markdownlint-disable MD013 -->
+## Required Inputs
+
+No required inputs.
+
+## Optional Inputs
+
+No optional inputs.
+
+## Outputs
+
+The following outputs are exported:
+
+### <a name="output_test_public_ip_address_id"></a> [test\_public\_ip\_address\_id](#output\_test\_public\_ip\_address\_id)
+
+Description: The ID of the Public IP Address
+
+### <a name="output_test_virtual_network_gateway_id"></a> [test\_virtual\_network\_gateway\_id](#output\_test\_virtual\_network\_gateway\_id)
+
+Description: The ID of the Virtual Network Gateway
+
+## Modules
+
+The following Modules are called:
+
+### <a name="module_vgw"></a> [vgw](#module\_vgw)
+
+Source: ../..
+
+Version:
+
+# Usage
+
+Ensure you have Terraform installed and the Azure CLI authenticated to your Azure subscription.
+
+Navigate to the directory containing this configuration and run:
+
+```pwsh
+terraform init
+terraform plan
+terraform apply
+```
+<!-- markdownlint-disable-next-line MD041 -->
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the repository. There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft’s privacy statement. Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.
+
+## AVM Versioning Notice
+
+Major version Zero (0.y.z) is for initial development. Anything MAY change at any time. The module SHOULD NOT be considered stable till at least it is major version one (1.0.0) or greater. Changes will always be via new versions being published and no changes will be made to existing published versions. For more details please go to <https://semver.org/>
+<!-- END_TF_DOCS -->

--- a/examples/default-with-hobo-ip/main.tf
+++ b/examples/default-with-hobo-ip/main.tf
@@ -1,0 +1,30 @@
+resource "random_id" "id" {
+  byte_length = 4
+}
+
+locals {
+  location = "uksouth"
+}
+
+resource "azurerm_resource_group" "rg" {
+  location = local.location
+  name     = "rg-vnetgateway-${random_id.id.hex}"
+}
+
+resource "azurerm_virtual_network" "vnet" {
+  location            = azurerm_resource_group.rg.location
+  name                = "vnet-${random_id.id.hex}"
+  resource_group_name = azurerm_resource_group.rg.name
+  address_space       = ["10.0.0.0/16"]
+}
+
+module "vgw" {
+  source = "../.."
+
+  location              = azurerm_resource_group.rg.location
+  name                  = "vgw-${random_id.id.hex}"
+  subnet_address_prefix = "10.0.1.0/24"
+  virtual_network_id    = azurerm_virtual_network.vnet.id
+  hosted_on_behalf_of_public_ip_enabled = true
+}
+

--- a/examples/default-with-hobo-ip/outputs.tf
+++ b/examples/default-with-hobo-ip/outputs.tf
@@ -1,0 +1,9 @@
+output "test_public_ip_address_id" {
+  description = "The ID of the Public IP Address"
+  value       = module.vgw.public_ip_addresses["001"].id
+}
+
+output "test_virtual_network_gateway_id" {
+  description = "The ID of the Virtual Network Gateway"
+  value       = module.vgw.virtual_network_gateway.id
+}

--- a/examples/default-with-hobo-ip/terraform.tf
+++ b/examples/default-with-hobo-ip/terraform.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = ">=1.2"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}

--- a/locals.tf
+++ b/locals.tf
@@ -4,7 +4,7 @@ locals {
   azurerm_local_network_gateway = {
     for local_network_gateway_key, local_network_gateway in var.local_network_gateways : local_network_gateway_key => local_network_gateway if local_network_gateway.id == null
   }
-  azurerm_public_ip = {
+  azurerm_public_ip = var.hosted_on_behalf_of_public_ip_enabled ? {} : {
     for ip_configuration_key, ip_configuration in local.ip_configurations : ip_configuration_key => {
       name                    = ip_configuration.public_ip.name
       resource_group_name     = coalesce(var.resource_group_name, ip_configuration.public_ip.resource_group_name, local.virtual_network_resource_group_name)
@@ -40,7 +40,7 @@ locals {
     ip_configuration = {
       for ip_configuration_key, ip_configuration in local.ip_configurations : ip_configuration_key => {
         name                          = ip_configuration.name
-        public_ip_address_id          = ip_configuration.public_ip.creation_enabled ? azurerm_public_ip.vgw[ip_configuration_key].id : ip_configuration.public_ip.id
+        public_ip_address_id          = var.hosted_on_behalf_of_public_ip_enabled ? null : (ip_configuration.public_ip.creation_enabled ? azurerm_public_ip.vgw[ip_configuration_key].id : ip_configuration.public_ip.id)
         subnet_id                     = var.subnet_creation_enabled ? azurerm_subnet.vgw[0].id : var.virtual_network_gateway_subnet_id
         private_ip_address_allocation = ip_configuration.private_ip_address_allocation
       }

--- a/variables.tf
+++ b/variables.tf
@@ -601,3 +601,10 @@ variable "vpn_type" {
     error_message = "vpn_type possible values are PolicyBased or RouteBased."
   }
 }
+
+variable "hosted_on_behalf_of_public_ip_enabled" {
+  type        = bool
+  default     = false
+  description = "Whether or not to attach a Public IP Address for the Virtual Network Gateway. ExpressRoute Gateways are implementing HOBO (hosted on behalf of) public IPs. This is a breaking change and requires the public IP to be turned off and not assigned."
+  nullable    = false
+}


### PR DESCRIPTION
## Description

ExpressRoute Gateways are transitioning to HOBO (hosted on behalf of) public IPs. This is a breaking change that results in idempotency and errors.

It is impossible for us to predict which regions and subscriptions have this feature enabled.

This flag is being added to allow customers to control this themselves once they see the errors and idempotency issues.

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
