### PR TITLE
Bug/express route circuit peering config

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -212,7 +212,6 @@ resource "azurerm_express_route_circuit_peering" "vgw" {
 
   dynamic "microsoft_peering_config" {
     for_each = each.value.microsoft_peering_config == null ? [] : ["MicrosoftPeeringConfig"]
-    iterator = ms_peering
 
     content {
       advertised_public_prefixes = each.value.microsoft_peering_config.advertised_public_prefixes

--- a/main.tf
+++ b/main.tf
@@ -212,12 +212,13 @@ resource "azurerm_express_route_circuit_peering" "vgw" {
 
   dynamic "microsoft_peering_config" {
     for_each = each.value.microsoft_peering_config == null ? [] : ["MicrosoftPeeringConfig"]
+    iterator = ms_peering
 
     content {
-      advertised_public_prefixes = each.value.advertised_public_prefixes
-      advertised_communities     = each.value.advertised_communities
-      customer_asn               = each.value.customer_asn
-      routing_registry_name      = each.value.routing_registry_name
+      advertised_public_prefixes = each.value.microsoft_peering_config.advertised_public_prefixes
+      advertised_communities     = each.value.microsoft_peering_config.advertised_communities
+      customer_asn               = each.value.microsoft_peering_config.customer_asn
+      routing_registry_name      = each.value.microsoft_peering_config.routing_registry_name
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -214,10 +214,10 @@ resource "azurerm_express_route_circuit_peering" "vgw" {
     for_each = each.value.microsoft_peering_config == null ? [] : ["MicrosoftPeeringConfig"]
 
     content {
-      advertised_public_prefixes = each.value.microsoft_advertised_public_prefixes
-      advertised_communities     = each.value.microsoft_advertised_communities
-      customer_asn               = each.value.microsoft_customer_asn
-      routing_registry_name      = each.value.microsoft_routing_registry_name
+      advertised_public_prefixes = each.value.advertised_public_prefixes
+      advertised_communities     = each.value.advertised_communities
+      customer_asn               = each.value.customer_asn
+      routing_registry_name      = each.value.routing_registry_name
     }
   }
 }


### PR DESCRIPTION
## Description

Fixes an issue where trying to provision an express route circuit peering is not possible because of a mismatch in the required attribute names of this root module and azurerm_express_route_circuit_peering's dynamic microsoft peering config block.

Previously the error caused by this bug:

```@HCL
Error: Unsupported attribute
│
│   on .terraform\modules\hub_and_spoke_vnet.virtual_network_gateway\main.tf line 217, in resource "azurerm_express_route_circuit_peering" "vgw":   
│  217:       advertised_public_prefixes = each.value.microsoft_advertised_public_prefixes
│     ├────────────────
│     │ each.value is object with 11 attributes
│
│ This object does not have an attribute named "microsoft_advertised_public_prefixes".
╵
╷
│ Error: Unsupported attribute
│
│   on .terraform\modules\hub_and_spoke_vnet.virtual_network_gateway\main.tf line 218, in resource "azurerm_express_route_circuit_peering" "vgw":   
│  218:       advertised_communities     = each.value.microsoft_advertised_communities
│     ├────────────────
│     │ each.value is object with 11 attributes
│
│ This object does not have an attribute named "microsoft_advertised_communities".
╵
╷
│ Error: Unsupported attribute
│
│   on .terraform\modules\hub_and_spoke_vnet.virtual_network_gateway\main.tf line 219, in resource "azurerm_express_route_circuit_peering" "vgw":   
│  219:       customer_asn               = each.value.microsoft_customer_asn
│     ├────────────────
│     │ each.value is object with 11 attributes
│
│ This object does not have an attribute named "microsoft_customer_asn".
╵
╷
│ Error: Unsupported attribute
│
│   on .terraform\modules\hub_and_spoke_vnet.virtual_network_gateway\main.tf line 220, in resource "azurerm_express_route_circuit_peering" "vgw":   
│  220:       routing_registry_name      = each.value.microsoft_routing_registry_name
│     ├────────────────
│     │ each.value is object with 11 attributes
│
│ This object does not have an attribute named "microsoft_routing_registry_name".
```

## Resolution

Added iterator with unique name to clearly identify the respective for_each loop iterators and corrected the object attribute names.

<img width="2044" height="1030" alt="image" src="https://github.com/user-attachments/assets/a61f973a-6b51-4b89-b1ee-6614385125ac" />


## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [x] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
