### PR TITLE
fix: increase default timeouts of VPN Gateway azapi resource

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -66,12 +66,12 @@ resource "azapi_resource" "vgw" {
   response_export_values = ["*"]
   tags                   = var.tags
   update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
-  
+
   timeouts {
     create = "2h"
+    delete = "2h"
     read   = "5m"
     update = "2h"
-    delete = "2h"
   }
 
   lifecycle {


### PR DESCRIPTION
## Description

- **Modified:** `azapi_resource "vgw"`
- **Added:** `timeouts` block with:
  ```hcl
  timeouts {
    create = "2h"
    delete = "2h"
    read   = "5m"
    update = "2h"
  }
- **Reason:**  
  Azure Virtual Network Gateway provisioning and updates can take over **30 minutes**.  
  By explicitly setting longer timeouts, we avoid Terraform failures during lengthy gateway operations.

Fixes Azure/terraform-azurerm-avm-ptn-alz-connectivity-hub-and-spoke-vnet#61 
Closes Azure/terraform-azurerm-avm-ptn-alz-connectivity-hub-and-spoke-vnet#61 

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
