### PR TITLE
Fix: VPN Gateway Point to Site Root Certificates

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -152,8 +152,10 @@ locals {
       # Root Certificates
       vpnClientRootCertificates = [
         for root_cert in var.vpn_point_to_site.root_certificates : {
-          name           = root_cert.name
-          publicCertData = root_cert.public_cert_data
+          name = root_cert.name
+          properties = {
+            publicCertData = root_cert.public_cert_data
+          }
         }
       ]
 


### PR DESCRIPTION
## Description

- **Modified:** `locals` block with:
  ```hcl
      # Root Certificates
      vpnClientRootCertificates = [
        for root_cert in var.vpn_point_to_site.root_certificates : {
          name = root_cert.name
          properties = {
            publicCertData = root_cert.public_cert_data
          }
        }
      ]
- **Reason:**  
  AzApi expects **publicCertData** to be wrapped in a **properties** block. The current version appears to be an artifact from when **azurerm** was used to provision the Vnet Gateway

Fixes #137  
Closes #137 

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
